### PR TITLE
Use jacoco snapshot for filtering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Logger
 ========
 
-Simple alternative to android Log
+Simple alternative to android Log.
 
 Sample
 ------
@@ -32,6 +32,13 @@ Maven
 Gradle
 ```groovy
 compile 'io.github.dmitrikudrenko:logger:$latestVersion'
+```
+
+Run tests (99% test coverage)
+=============================
+```groovy
+gradlew testDebugUnitTestCoverage --for Debug
+gradlew testReleaseUnitTestCoverage --for Release
 ```
 
 License

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.novoda:bintray-release:0.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
     }
 }
 
@@ -17,6 +16,7 @@ allprojects {
         jcenter()
         google()
         mavenCentral()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 }
 

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,0 +1,55 @@
+apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = "0.7.10-SNAPSHOT"
+}
+
+project.afterEvaluate {
+    // Grab all build types and product flavors
+    def buildTypes = android.buildTypes.collect { type -> type.name }
+    def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
+
+    // When no product flavors defined, use empty
+    if (!productFlavors) productFlavors.add('')
+
+    productFlavors.each { productFlavorName ->
+        buildTypes.each { buildTypeName ->
+            def sourceName, sourcePath
+            if (!productFlavorName) {
+                sourceName = sourcePath = "${buildTypeName}"
+            } else {
+                sourceName = "${productFlavorName}${buildTypeName.capitalize()}"
+                sourcePath = "${productFlavorName}/${buildTypeName}"
+            }
+            def testTaskName = "test${sourceName.capitalize()}UnitTest"
+
+            // Create coverage task of form 'testFlavorTypeCoverage' depending on 'testFlavorTypeUnitTest'
+            task "${testTaskName}Coverage" (type:JacocoReport, dependsOn: "$testTaskName") {
+                group = "Reporting"
+                description = "Generate Jacoco coverage reports on the ${sourceName.capitalize()} build."
+
+                classDirectories = fileTree(
+                        dir: "${project.buildDir}/intermediates/classes/${sourcePath}",
+                        excludes: ['**/R.class',
+                                   '**/R$*.class',
+                                   '**/BuildConfig.*',
+                                   '**/Manifest*.*']
+                )
+
+                def coverageSourceDirs = [
+                        "src/main/java",
+                        "src/$productFlavorName/java",
+                        "src/$buildTypeName/java"
+                ]
+                additionalSourceDirs = files(coverageSourceDirs)
+                sourceDirectories = files(coverageSourceDirs)
+                executionData = files("${project.buildDir}/jacoco/${testTaskName}.exec")
+
+                reports {
+                    xml.enabled = true
+                    html.enabled = true
+                }
+            }
+        }
+    }
+}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.novoda.bintray-release'
-apply plugin: 'jacoco-android'
+apply from: '../jacoco.gradle'
 
 publish {
     groupId = 'io.github.dmitrikudrenko'
@@ -27,6 +27,9 @@ android {
 
     }
     buildTypes {
+        debug {
+            testCoverageEnabled = true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -53,7 +56,5 @@ dependencies {
     implementation 'com.android.support:support-annotations:27.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-all:2.0.2-beta'
-    testImplementation 'org.robolectric:robolectric:3.4.2'
-    testImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }

--- a/library/src/main/java/io/github/dmitrikudrenko/logger/Log.java
+++ b/library/src/main/java/io/github/dmitrikudrenko/logger/Log.java
@@ -16,10 +16,33 @@ public final class Log {
     public static final Level VERBOSE = new Verbose();
     public static final Level DEBUG = new Debug();
 
-    private static Formatter logcatFormatter;
-    private static Formatter formatter;
+    @SuppressWarnings("WeakerAccess")
+    @VisibleForTesting
+    static Formatter logcatFormatter;
+    @SuppressWarnings("WeakerAccess")
+    @VisibleForTesting
+    static Formatter formatter;
+
     private static Logger logger;
     private static Handler handler;
+
+    @SuppressWarnings("WeakerAccess")
+    @VisibleForTesting
+    static final Formatter DEFAULT_LOGCAT_FORMATTER = new Formatter() {
+        @Override
+        public String format(LogRecord record) {
+            return Utils.formatForConsole(record);
+        }
+    };
+
+    @SuppressWarnings("WeakerAccess")
+    @VisibleForTesting
+    static final Formatter DEFAULT_FORMATTER = new Formatter() {
+        @Override
+        public String format(LogRecord record) {
+            return Utils.format(record);
+        }
+    };
 
     private Log() {
     }
@@ -37,18 +60,8 @@ public final class Log {
     }
 
     private static void initDefaultFormatters() {
-        logcatFormatter = new Formatter() {
-            @Override
-            public String format(LogRecord record) {
-                return Utils.formatForConsole(record);
-            }
-        };
-        formatter = new Formatter() {
-            @Override
-            public String format(LogRecord record) {
-                return Utils.format(record);
-            }
-        };
+        logcatFormatter = DEFAULT_LOGCAT_FORMATTER;
+        formatter = DEFAULT_FORMATTER;
     }
 
     private static void initDefaultHandler() {

--- a/library/src/main/java/io/github/dmitrikudrenko/logger/impl/AndroidHandler.java
+++ b/library/src/main/java/io/github/dmitrikudrenko/logger/impl/AndroidHandler.java
@@ -21,7 +21,12 @@ public class AndroidHandler extends Handler {
         if (tag.length() > 23) {
             tag = tag.substring(0, 23);
         }
-        Log.println(getAndroidLevel(level), tag, getFormatter().format(record));
+        printLog(level, tag, getFormatter().format(record));
+    }
+
+    @VisibleForTesting
+    void printLog(Level level, String tag, String message) {
+        Log.println(getAndroidLevel(level), tag, message);
     }
 
     @VisibleForTesting

--- a/library/src/test/kotlin/io/github/dmitrikudrenko/logger/LogPublishTest.kt
+++ b/library/src/test/kotlin/io/github/dmitrikudrenko/logger/LogPublishTest.kt
@@ -1,18 +1,13 @@
 package io.github.dmitrikudrenko.logger
 
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Matchers.argThat
 import org.mockito.Mockito
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.logging.Handler
 import java.util.logging.Level
 import java.util.logging.LogRecord
 
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
 class LogPublishTest : BasePublishTest() {
 
     @Test

--- a/library/src/test/kotlin/io/github/dmitrikudrenko/logger/LogSetupTest.kt
+++ b/library/src/test/kotlin/io/github/dmitrikudrenko/logger/LogSetupTest.kt
@@ -4,18 +4,13 @@ import io.github.dmitrikudrenko.logger.impl.AndroidHandler
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Matchers
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.logging.Formatter
 import java.util.logging.Handler
 import java.util.logging.Logger
 
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
 class LogSetupTest {
     private var logger: Logger? = null
     private var handler: Handler? = null

--- a/library/src/test/kotlin/io/github/dmitrikudrenko/logger/LogTestUtils.kt
+++ b/library/src/test/kotlin/io/github/dmitrikudrenko/logger/LogTestUtils.kt
@@ -1,0 +1,51 @@
+package io.github.dmitrikudrenko.logger
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import java.util.logging.Formatter
+
+class LogTestUtils {
+    private lateinit var logcatFormatter: Formatter
+    private lateinit var formatter: Formatter
+
+    @Before
+    fun `set up`() {
+        logcatFormatter = mock(Formatter::class.java)
+        formatter = mock(Formatter::class.java)
+    }
+
+    @Test
+    fun `should set default formatters 1`() {
+        Log.setFormatter(logcatFormatter, null)
+        Log.setup()
+        assertNotEquals(Log.logcatFormatter, logcatFormatter)
+        assertNotEquals(Log.formatter, formatter)
+    }
+
+    @Test
+    fun `should set default formatters 2`() {
+        Log.setFormatter(null, formatter)
+        Log.setup()
+        assertNotEquals(Log.logcatFormatter, logcatFormatter)
+        assertNotEquals(Log.formatter, formatter)
+    }
+
+    @Test
+    fun `should set default formatters 3`() {
+        Log.setFormatter(null, null)
+        Log.setup()
+        assertNotEquals(Log.logcatFormatter, logcatFormatter)
+        assertNotEquals(Log.formatter, formatter)
+    }
+
+    @Test
+    fun `should set default formatters 4`() {
+        Log.setFormatter(logcatFormatter, formatter)
+        Log.setup()
+        assertEquals(Log.logcatFormatter, logcatFormatter)
+        assertEquals(Log.formatter, formatter)
+    }
+}

--- a/library/src/test/kotlin/io/github/dmitrikudrenko/logger/TestUtils.kt
+++ b/library/src/test/kotlin/io/github/dmitrikudrenko/logger/TestUtils.kt
@@ -3,16 +3,24 @@ package io.github.dmitrikudrenko.logger
 import io.github.dmitrikudrenko.logger.events.LogEvent
 import org.mockito.ArgumentMatcher
 import org.mockito.Mockito
+import org.mockito.Mockito.mock
 import java.util.concurrent.Executor
 import java.util.logging.Level
 import java.util.logging.LogRecord
 
 val MOCK_TAG = "tag"
+val MOCK_LONG_TAG = "Long long long long long tag"
 val MOCK_MESSAGE = "message"
 val MOCK_EXCEPTION = Exception("exception")
 
 val MOCK_EVENT_VALUE = "value"
 val MOCK_EVENT = LogEvent { MOCK_EVENT_VALUE }
+
+val MOCK_LEVEL = mock(Level::class.java)
+
+val MOCK_LOG_RECORD = LogRecord(MOCK_LEVEL, MOCK_MESSAGE).apply { this.loggerName = MOCK_TAG }
+val MOCK_LONG_LOG_RECORD = LogRecord(MOCK_LEVEL, MOCK_MESSAGE).apply { this.loggerName = MOCK_LONG_TAG }
+val MOCK_LOG_RECORD_W_ERROR = LogRecord(MOCK_LEVEL, MOCK_MESSAGE).apply { this.thrown = MOCK_EXCEPTION }
 
 class LogRecordMatcher(private val level: Level,
                        private val tag: String,

--- a/library/src/test/kotlin/io/github/dmitrikudrenko/logger/events/ActivityLifecycleEventTest.kt
+++ b/library/src/test/kotlin/io/github/dmitrikudrenko/logger/events/ActivityLifecycleEventTest.kt
@@ -5,16 +5,11 @@ import io.github.dmitrikudrenko.logger.Log
 import io.github.dmitrikudrenko.logger.LogRecordMatcher
 import io.github.dmitrikudrenko.logger.MOCK_TAG
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Matchers
 import org.mockito.Mockito
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.logging.Handler
 import java.util.logging.Level
 
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
 class ActivityLifecycleEventTest : BasePublishTest() {
     @Test
     fun `should publish "Start" activity event`() {

--- a/library/src/test/kotlin/io/github/dmitrikudrenko/logger/events/FragmentLifecycleEventTest.kt
+++ b/library/src/test/kotlin/io/github/dmitrikudrenko/logger/events/FragmentLifecycleEventTest.kt
@@ -5,16 +5,11 @@ import io.github.dmitrikudrenko.logger.Log
 import io.github.dmitrikudrenko.logger.LogRecordMatcher
 import io.github.dmitrikudrenko.logger.MOCK_TAG
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Matchers.argThat
 import org.mockito.Mockito
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.logging.Handler
 import java.util.logging.Level
 
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
 class FragmentLifecycleEventTest : BasePublishTest() {
 
     @Test

--- a/library/src/test/kotlin/io/github/dmitrikudrenko/logger/events/ViewEventTest.kt
+++ b/library/src/test/kotlin/io/github/dmitrikudrenko/logger/events/ViewEventTest.kt
@@ -5,16 +5,11 @@ import io.github.dmitrikudrenko.logger.Log
 import io.github.dmitrikudrenko.logger.LogRecordMatcher
 import io.github.dmitrikudrenko.logger.MOCK_TAG
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mockito.argThat
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.logging.Handler
 import java.util.logging.Level
 
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
 class ViewEventTest : BasePublishTest() {
 
     @Test

--- a/library/src/test/kotlin/io/github/dmitrikudrenko/logger/impl/AndroidHandlerTest.kt
+++ b/library/src/test/kotlin/io/github/dmitrikudrenko/logger/impl/AndroidHandlerTest.kt
@@ -1,15 +1,12 @@
 package io.github.dmitrikudrenko.logger.impl
 
-import io.github.dmitrikudrenko.logger.Log
+import io.github.dmitrikudrenko.logger.*
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mockito.Mockito.*
+import java.util.logging.Formatter
 import java.util.logging.Level
 
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
 class AndroidHandlerTest {
     @Test
     fun `should return android-util-Log*ERROR if java-util-logging-Level*SEVERE`() {
@@ -34,5 +31,19 @@ class AndroidHandlerTest {
     @Test
     fun `should return android-util-Log*DEBUG if Log*DEBUG`() {
         assertEquals(android.util.Log.DEBUG, AndroidHandler.getAndroidLevel(Log.DEBUG))
+    }
+
+    @Test
+    fun `should publish`() {
+        val handler = spy(AndroidHandler().apply { formatter = mock(Formatter::class.java) })
+        handler.publish(MOCK_LOG_RECORD)
+        verify(handler).printLog(eq(MOCK_LEVEL), eq(MOCK_TAG), any())
+    }
+
+    @Test
+    fun `should publish long tag`() {
+        val handler = spy(AndroidHandler().apply { formatter = mock(Formatter::class.java) })
+        handler.publish(MOCK_LONG_LOG_RECORD)
+        verify(handler).printLog(eq(MOCK_LEVEL), eq("Long long long long lon"), any())
     }
 }

--- a/library/src/test/kotlin/io/github/dmitrikudrenko/logger/impl/FileHandlerTest.kt
+++ b/library/src/test/kotlin/io/github/dmitrikudrenko/logger/impl/FileHandlerTest.kt
@@ -1,29 +1,19 @@
 package io.github.dmitrikudrenko.logger.impl
 
-import io.github.dmitrikudrenko.logger.Log
-import io.github.dmitrikudrenko.logger.MOCK_MESSAGE
-import io.github.dmitrikudrenko.logger.MOCK_TAG
-import io.github.dmitrikudrenko.logger.`make executor sync`
+import io.github.dmitrikudrenko.logger.*
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mockito.*
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.lang.IllegalArgumentException
 import java.util.concurrent.Executor
-import java.util.logging.Level
 import java.util.logging.LogRecord
 
 
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
 class FileHandlerTest {
     private val pattern = "pattern"
     private var handler: FileHandler? = null
     private var executor: Executor? = null
-    private var logRecord: LogRecord? = null
 
     @Before
     fun `set up`() {
@@ -31,7 +21,6 @@ class FileHandlerTest {
         executor = mock(Executor::class.java)
         handler?.setExecutor(executor)
         Log.addHandler(handler)
-        logRecord = LogRecord(Level.INFO, MOCK_MESSAGE)
     }
 
     @After
@@ -47,15 +36,15 @@ class FileHandlerTest {
 
     @Test
     fun `should service be executed if publish`() {
-        handler?.publish(logRecord)
+        handler?.publish(MOCK_LOG_RECORD)
         verify<Executor>(executor).execute(any())
     }
 
     @Test
     fun `should do publish be executed if publish`() {
         `make executor sync`(executor!!)
-        handler?.publish(logRecord)
-        verify<FileHandler>(handler).doPublish(logRecord)
+        handler?.publish(MOCK_LOG_RECORD)
+        verify<FileHandler>(handler).doPublish(MOCK_LOG_RECORD)
     }
 
     @Test

--- a/library/src/test/kotlin/io/github/dmitrikudrenko/logger/utils/UtilsTest.kt
+++ b/library/src/test/kotlin/io/github/dmitrikudrenko/logger/utils/UtilsTest.kt
@@ -1,19 +1,11 @@
 package io.github.dmitrikudrenko.logger.utils
 
-import io.github.dmitrikudrenko.logger.MOCK_EXCEPTION
-import io.github.dmitrikudrenko.logger.MOCK_MESSAGE
-import io.github.dmitrikudrenko.logger.MOCK_TAG
+import io.github.dmitrikudrenko.logger.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-import java.util.logging.Level
 import java.util.logging.LogRecord
 
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
 class UtilsTest {
     @Test
     fun `should convert throwable to string`() {
@@ -38,21 +30,17 @@ class UtilsTest {
 
     @Test
     fun `should return only message if record has not exception`() {
-        assertEquals(MOCK_MESSAGE, Utils.formatForConsole(LogRecord(Level.INFO, MOCK_MESSAGE)))
+        assertEquals(MOCK_MESSAGE, Utils.formatForConsole(LogRecord(MOCK_LEVEL, MOCK_MESSAGE)))
     }
 
     @Test
     fun `should return exception stacktrace if record has exception`() {
-        val logRecord = LogRecord(Level.INFO, MOCK_MESSAGE)
-        logRecord.thrown = MOCK_EXCEPTION
-        val message = Utils.formatForConsole(logRecord)
+        val message = Utils.formatForConsole(MOCK_LOG_RECORD_W_ERROR)
         assertTrue(message.startsWith("java.lang.Exception: exception"))
     }
 
     @Test
     fun `should output format message`() {
-        val logRecord = LogRecord(Level.INFO, MOCK_MESSAGE)
-        logRecord.loggerName = MOCK_TAG
-        assertEquals("tag: message\n", Utils.format(logRecord))
+        assertEquals("tag: message\n", Utils.format(MOCK_LOG_RECORD))
     }
 }


### PR DESCRIPTION
Подключил snapshot Jacoco, в котором реализована функция Filtering options. Она позволяет не учитывать в покрытии ```Enum.valueOf``` и ```Enum.values``` в нашем случае (что дает подъем до 96%)